### PR TITLE
Video Positioning and Multiple Videos

### DIFF
--- a/index.html.template
+++ b/index.html.template
@@ -69,7 +69,7 @@ div#footer {
 </style>
 </head>
 <body onload="init()"><div id="overview" style="display: none;"></div>
-<div id="presenterconsole"><img id="slide" height="100%"/><video id="video" height="100%" style="display: none;" ></video>
+<div id="presenterconsole"><img id="slide" height="100%"/>
 <img id="slide-next" style="display: none;"/><span id="slide-annot" style="display: none;"></span>
 <button onclick="openSlides()" id="open-btn" >
 <img src="data:image/svg+xml;base64,{{open.svg}}"/> <span id="slides-open">&nbsp; Open Slides</span>
@@ -125,61 +125,69 @@ div#footer {
     }
 
     function slideType(type) {
+        document.querySelectorAll('[id^="video"]').forEach(el => el.parentNode.removeChild(el));
         if(type == "image") {
             document.getElementById("slide").style.display = "";
-            document.getElementById("video").style.display = "none";
-            document.getElementById("video").innerHTML = "";
         } else if(type == "video") {
             document.getElementById("slide").style.display = "none";
-            document.getElementById("video").style.display = "";
         } else if (type == "video_embedded") {
             document.getElementById("slide").style.display = "";
-            document.getElementById("video").style.display = "";
         }
     }
 
     function redraw() {
     
         if(slide_video[slide] != "") {
-            slideType("video");
+            var urls = atob(slide_video[slide]).substring(1).split('|');
 
-            var url = atob(slide_video[slide]);
-//             console.log("found video " + url);
-            var video_elem = document.getElementById("video");
-            video_elem.innerHTML = "<source src=\"" + url + "\">";
-
+            var video_pos = "";
             if (slide_video_pos[slide] != "") {
-                var coords = slide_video_pos[slide].split(';').map(parseFloat);
+                video_pos = slide_video_pos[slide].substring(1).split('|');
                 slideType("video_embedded");
                 document.getElementById("slide").src = (black && !presenter) ? "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" : "data:image/svg+xml;base64," + slide_img[slide];
-
-                var slide_style = window.getComputedStyle(document.getElementById("slide"));
-
-                var slide_width = parseInt(slide_style.width);
-                var slide_height = parseInt(slide_style.height);
-
-                video_elem.style.width = ((coords[2] - coords[0]) * slide_width).toString() + "px";
-                video_elem.style.height = ((coords[3] - coords[1]) * slide_height).toString() + "px";
-
-                video_elem.style.left = (coords[0] * slide_width).toString() + "px";
-                video_elem.style.top = ((1.0 - coords[3]) * slide_height).toString() + "px";
-
-                video_elem.style.position = "absolute";
-                video_elem.poster = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAQAAADYv8WvAAAADklEQVR42mNkAAJGEAEAABkAA50Y5HIAAAAASUVORK5CYII=";
             } else {
                 slideType("video");
-                video_elem.poster = "data:image/svg+xml;base64," + slide_img[slide];
             }
 
-            video_elem.load();
-            video_elem.pause();
-            video_elem.currentTime = 0;
-            if(url.indexOf("?autostart") != -1 /*&& !presenter*/) {
-                video_elem.muted = true;
-                video_elem.autoplay = true;
-                video_elem.play();
+            for (var i = 0; i < urls.length; i++) {
+                var slide_elem = document.getElementById("slide");
+
+                var video_elem = document.createElement('video');
+                video_elem.id = 'video' + i.toString();
+                video_elem.height = "100%";
+                slide_elem.parentNode.insertBefore(video_elem, slide_elem.nextSibling);
+
+                video_elem.innerHTML = "<source src=\"" + urls[i] + "\">";
+
+                if (video_pos[i] && video_pos[i] != "") {
+                    var coords = video_pos[i].split(';').map(parseFloat);
+
+                    var slide_style = window.getComputedStyle(document.getElementById("slide"));
+                    var slide_width = parseInt(slide_style.width);
+                    var slide_height = parseInt(slide_style.height);
+
+                    video_elem.style.width = ((coords[2] - coords[0]) * slide_width).toString() + "px";
+                    video_elem.style.height = ((coords[3] - coords[1]) * slide_height).toString() + "px";
+
+                    video_elem.style.left = (coords[0] * slide_width).toString() + "px";
+                    video_elem.style.top = ((1.0 - coords[3]) * slide_height).toString() + "px";
+
+                    video_elem.style.position = "absolute";
+                    video_elem.poster = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAQAAADYv8WvAAAADklEQVR42mNkAAJGEAEAABkAA50Y5HIAAAAASUVORK5CYII=";
+                } else {
+                    video_elem.poster = "data:image/svg+xml;base64," + slide_img[slide];
+                }
+
+                video_elem.load();
+                video_elem.pause();
+                video_elem.currentTime = 0;
+                if(urls[i].indexOf("?autostart") != -1 /*&& !presenter*/) {
+                    video_elem.muted = true;
+                    video_elem.autoplay = true;
+                    video_elem.play();
+                }
+                video_elem.controls = true;
             }
-            video_elem.controls = true;
         } else {
             slideType("image");
 

--- a/index.html.template
+++ b/index.html.template
@@ -396,7 +396,6 @@ div#footer {
             presenter = true;
             document.getElementById("slide").style.width="70%";
             document.getElementById("slide").style.backgroundColor="white";
-            document.getElementById("video").style.width="70%";
             document.getElementById("slide").style.height="auto";
             document.getElementById("slide-next").style.width="30%";
             document.getElementById("slide-next").style.backgroundColor="white";

--- a/index.html.template
+++ b/index.html.template
@@ -159,7 +159,7 @@ div#footer {
 
                 video_elem.innerHTML = "<source src=\"" + urls[i] + "\">";
 
-                if (video_pos[i] && video_pos[i] != "") {
+                if (video_pos[i] && video_pos[i] != "" && video_pos[i].split(';').length == 4) {
                     var coords = video_pos[i].split(';').map(parseFloat);
 
                     var slide_style = window.getComputedStyle(document.getElementById("slide"));

--- a/index.html.template
+++ b/index.html.template
@@ -8,11 +8,16 @@ body, html {
     overflow-x: hidden;
     overflow-y: auto;
 }
-img#slide, video#video {
+img#slide {
+    float: left;
+    background-color: white;
+}
+video#video {
     float: left;
 }
 img#slide-next {
     float: right;
+    background-color: white;
 }
 #slide-annot {
     color: white;
@@ -94,6 +99,7 @@ div#footer {
     
     var slide_img = slide_info["slides"];
     var slide_video = slide_info["videos"];
+    var slide_video_pos = slide_info["videos_pos"];
     var slide_annot = slide_info["annotations"];
     var slide_thumb = slide_info["thumb"];
 
@@ -117,15 +123,17 @@ div#footer {
         slide = sid;
         redraw();
     }
-    
+
     function slideType(type) {
         if(type == "image") {
             document.getElementById("slide").style.display = "";
             document.getElementById("video").style.display = "none";
             document.getElementById("video").innerHTML = "";
-            
         } else if(type == "video") {
             document.getElementById("slide").style.display = "none";
+            document.getElementById("video").style.display = "";
+        } else if (type == "video_embedded") {
+            document.getElementById("slide").style.display = "";
             document.getElementById("video").style.display = "";
         }
     }
@@ -139,7 +147,30 @@ div#footer {
 //             console.log("found video " + url);
             var video_elem = document.getElementById("video");
             video_elem.innerHTML = "<source src=\"" + url + "\">";
-            video_elem.poster = "data:image/svg+xml;base64," + slide_img[slide];
+
+            if (slide_video_pos[slide] != "") {
+                var coords = slide_video_pos[slide].split(';').map(parseFloat);
+                slideType("video_embedded");
+                document.getElementById("slide").src = (black && !presenter) ? "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" : "data:image/svg+xml;base64," + slide_img[slide];
+
+                var slide_style = window.getComputedStyle(document.getElementById("slide"));
+
+                var slide_width = parseInt(slide_style.width);
+                var slide_height = parseInt(slide_style.height);
+
+                video_elem.style.width = ((coords[2] - coords[0]) * slide_width).toString() + "px";
+                video_elem.style.height = ((coords[3] - coords[1]) * slide_height).toString() + "px";
+
+                video_elem.style.left = (coords[0] * slide_width).toString() + "px";
+                video_elem.style.top = ((1.0 - coords[3]) * slide_height).toString() + "px";
+
+                video_elem.style.position = "absolute";
+                video_elem.poster = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAQAAADYv8WvAAAADklEQVR42mNkAAJGEAEAABkAA50Y5HIAAAAASUVORK5CYII=";
+            } else {
+                slideType("video");
+                video_elem.poster = "data:image/svg+xml;base64," + slide_img[slide];
+            }
+
             video_elem.load();
             video_elem.pause();
             video_elem.currentTime = 0;

--- a/utils.c
+++ b/utils.c
@@ -147,3 +147,21 @@ char *encode_array(SlideInfo *info, int offset, int len, int b64,
   strcat(buff, "]\n");
   return buff;
 }
+
+void append_elem(char **orig, const char *append, const char *split) {
+  char *tmp = NULL;
+
+  if (*orig == NULL) {
+    *orig = calloc(strlen(append) + strlen(split) + 1, sizeof(char));
+    strcat(*orig, split);
+    strcat(*orig, append);
+  } else {
+    tmp = calloc(strlen(*orig) + 1, sizeof(char));
+    memcpy(tmp, *orig, strlen(*orig));
+    *orig = calloc(strlen(*orig) + strlen(split) + strlen(append) + 1, sizeof(char));
+    strcat(*orig, tmp);
+    strcat(*orig, split);
+    strcat(*orig, append);
+    free(tmp);
+  }
+}

--- a/utils.h
+++ b/utils.h
@@ -17,4 +17,6 @@ char* encode_array(SlideInfo* info, int offset, int len, int b64,
                    progress_t cb);
 char* encode_array_base64(char* array, size_t len);
 
+void append_elem(char **orig, const char *append, const char *split);
+
 #endif

--- a/webslides.c
+++ b/webslides.c
@@ -114,13 +114,7 @@ int convert(PopplerPage *page, const char *fname, SlideInfo *info) {
         PopplerMovie *movie = poppler_annot_movie_get_movie(m->annot);
         if(movie) {
           char *movie_filename = strdup(poppler_movie_get_filename(movie));
-          char *movies_str =
-              malloc(strlen(info->videos) + 1 + strlen(movie_filename) + 1);
-          movies_str[0] = '\0';
-          strcat(movies_str, info->videos);
-          strcat(movies_str, "|");
-          strcat(movies_str, movie_filename);
-          info->videos = strdup(movies_str);
+          append_elem(&info->videos, movie_filename, "|");
 
           PopplerRectangle *rectangle = poppler_rectangle_new();
           poppler_annot_get_rectangle(m->annot, rectangle);
@@ -128,19 +122,15 @@ int convert(PopplerPage *page, const char *fname, SlideInfo *info) {
           double lly = rectangle->y1 / height;
           double urx = rectangle->x2 / width;
           double ury = rectangle->y2 / height;
-          size_t str_size =
+
+          size_t bbox_buffer_size =
               snprintf(NULL, 0, "%f;%f;%f;%f", llx, lly, urx, ury) + 1;
-          char *buffer = malloc(str_size);
-          sprintf(buffer, "%f;%f;%f;%f", llx, lly, urx, ury);
+          char *bbox_buffer = calloc(bbox_buffer_size, 1);
+          sprintf(bbox_buffer, "%f;%f;%f;%f", llx, lly, urx, ury);
+          append_elem(&info->videos_pos, bbox_buffer, "|");
 
-          char *movies_pos_str =
-              malloc(strlen(info->videos_pos) + 1 + strlen(buffer) + 1);
-          movies_pos_str[0] = '\0';
-          strcat(movies_pos_str, info->videos_pos);
-          strcat(movies_pos_str, "|");
-          strcat(movies_pos_str, buffer);
-
-          info->videos_pos = strdup(movies_pos_str);
+          free(movie_filename);
+          free(bbox_buffer);
           poppler_rectangle_free(rectangle);
         }
     }
@@ -157,13 +147,9 @@ int convert(PopplerPage *page, const char *fname, SlideInfo *info) {
       PopplerActionLaunch *launch = (PopplerActionLaunch *)a;
       //         printf("\n\n%s\n", launch->file_name);
       char *movie_filename = strdup(launch->file_name);
-      char *movies_str =
-          malloc(strlen(info->videos) + 1 + strlen(movie_filename) + 1);
-      movies_str[0] = '\0';
-      strcat(movies_str, info->videos);
-      strcat(movies_str, "|");
-      strcat(movies_str, movie_filename);
-      info->videos = strdup(movies_str);
+      append_elem(&info->videos, movie_filename, "|");
+
+      free(movie_filename);
     }
   }
   poppler_page_free_link_mapping(link_list);

--- a/webslides.h
+++ b/webslides.h
@@ -10,6 +10,7 @@ typedef struct __attribute__((packed)) {
   char* videos;
   char* slide;
   char* thumb;
+  char *videos_pos;
 } SlideInfo;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Some small modifications to retrieve the video bbox so that the video element has the original positioning and does not spawn over the entire page. Also quick and dirty support for multiple videos. Video DOMs are created dynamically instead of one static element. I checked with some files and it does not seem to break anything but maybe it needs some additional checks. 